### PR TITLE
Fix temp file existence check in macro

### DIFF
--- a/module.bas
+++ b/module.bas
@@ -256,7 +256,7 @@ Sub SaveAsPDFfile()
             sTempFileName = sTempFolder & "\outlook.mht"
 
             ' Kill the previous file if already present
-            If Dir(sTempFileName) Then Kill (sTempFileName)
+            If Len(Dir$(sTempFileName)) > 0 Then Kill sTempFileName
 
             ' Save the mht-file
             oMail.SaveAs sTempFileName, olMHTML


### PR DESCRIPTION
## Summary
- avoid runtime error 13 by comparing the Dir return value as a string

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6854f3a13b18832f9b957e169697ae36