### PR TITLE
Close Word doc after exporting

### DIFF
--- a/module.bas
+++ b/module.bas
@@ -702,6 +702,7 @@ NextSelectionItem:
 
         If fso.FileExists(pdfFile) Then fso.DeleteFile pdfFile, True
         doc.ExportAsFixedFormat pdfFile, wdExportFormatPDF
+        doc.Close False
 
         mailItem.Close olDiscard
         Set doc = Nothing


### PR DESCRIPTION
## Summary
- close the Word document after exporting to PDF to avoid memory issues

## Testing
- `grep -n "doc.Close False" -n module.bas`

------
https://chatgpt.com/codex/tasks/task_e_685572344330832f947f06252aa1f6bb