### PR TITLE
Add error-safe status bar reset

### DIFF
--- a/module.bas
+++ b/module.bas
@@ -690,7 +690,13 @@ NextItem:
     MsgBox msg, vbInformation, "Export Complete"
 
 Cleanup:
+    ' -- Safely reset status bars in Word and Outlook
+    On Error Resume Next
+    wrd.StatusBar = False                       ' Word
+    Application.ActiveExplorer.StatusBar = ""   ' Outlook
     Application.StatusBar = False
+    On Error GoTo 0
+
     On Error Resume Next
     If Not wrd Is Nothing Then wrd.Quit
     ' ... release all other objects ...


### PR DESCRIPTION
## Summary
- add a safety wrapper for turning off the status bar

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68558a06b20c832fb857ec8b5e1fb73f