### PR TITLE
Save attachments alongside exported email PDFs

### DIFF
--- a/module.bas
+++ b/module.bas
@@ -443,6 +443,7 @@ Public Sub SaveAsPDFfile()
     Dim sel As Outlook.Selection
     Dim wrd As Object, doc As Object, fso As Object
     Dim mailItem As Outlook.MailItem
+    Dim att As Outlook.Attachment
     Dim tgtFolder As String, logFilePath As String
     Dim done As Long, skipped As Long, total As Long
 
@@ -582,6 +583,25 @@ Public Sub SaveAsPDFfile()
             Err.Clear
         Else
             done = done + 1
+
+            ' --- SAVE ATTACHMENTS ---
+            Dim attFile As String, attBase As String, attExt As String
+            Dim attDup As Long
+            For Each att In mailItem.Attachments
+                attBase = CleanFile(att.FileName)
+                attExt = ""
+                If InStrRev(attBase, ".") > 0 Then
+                    attExt = Mid$(attBase, InStrRev(attBase, "."))
+                    attBase = Left$(attBase, InStrRev(attBase, ".") - 1)
+                End If
+                attFile = tgtFolder & baseName & "_" & attBase & attExt
+                attDup = 1
+                Do While fso.FileExists(attFile)
+                    attFile = tgtFolder & baseName & "_" & attBase & "_" & attDup & attExt
+                    attDup = attDup + 1
+                Loop
+                att.SaveAsFile attFile
+            Next att
         End If
 
 NextItem:

--- a/readme.md
+++ b/readme.md
@@ -53,8 +53,8 @@ Make sure Outlook actually loads the macros. By default Outlook disables them fo
 
 1. **Select the Emails**: Choose one or multiple emails you wish to save as PDFs.
 2. **Activate the Macro**: Click on the `SaveAsPDFfile` button (or use `SaveSelectedMails_AsPDF_NoPopups` for silent exports) on your custom ribbon.
-3. **Specify Save Location**: Follow the prompts to select a destination folder for the PDFs.
-4. **Completion**: Sit back and watch as your selected emails are transformed and saved as PDFs on your disk.
+3. **Specify Save Location**: Follow the prompts to select a destination folder for the PDFs and any attachments.
+4. **Completion**: Sit back and watch as your selected emails are transformed and saved as PDFs on your disk, with their attachments saved alongside them.
 
 ![Demonstration](images/demo.gif)
 


### PR DESCRIPTION
## Summary
- Extend `SaveAsPDFfile` to save each email's attachments alongside its PDF export.
- Document attachment-saving behaviour in the "How to Use" section.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68946d7fe3d0832f89d9ed538c0ba6f6