### PR TITLE
Add test for module Option Explicit line

### DIFF
--- a/tests/test_module_explicit.py
+++ b/tests/test_module_explicit.py
@@ -1,0 +1,6 @@
+import pathlib
+
+
+def test_module_has_option_explicit():
+    lines = pathlib.Path('module.bas').read_text(encoding='utf-8').splitlines()
+    assert 'Option Explicit' in lines


### PR DESCRIPTION
## Summary
- add a test ensuring `module.bas` declares `Option Explicit`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68946d7e4a04832f8e7600751be8fa30